### PR TITLE
Handle non-existent tool connection error

### DIFF
--- a/MAP_TROUBLESHOOTING.md
+++ b/MAP_TROUBLESHOOTING.md
@@ -16,7 +16,7 @@
    ```
 
 2. **訪問網頁**：
-   - 地圖測試：http://localhost:8000/map-test.html
+   - 地圖測試：http://localhost:8000/simple-map-test.html
    - 行程表：http://localhost:8000/index.html
    - 補給點：http://localhost:8000/supplies.html
 
@@ -74,7 +74,7 @@ GPX parsing failed
 Central-Mountain-Range-Trail/
 ├── index.html              # 主行程表
 ├── supplies.html           # 補給點頁面
-├── map-test.html          # 地圖測試頁面
+├── simple-map-test.html   # 地圖測試頁面
 ├── start-server.py        # 本地服務器
 ├── assets/
 │   └── gpx/

--- a/start-server.py
+++ b/start-server.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
         with socketserver.TCPServer(("", PORT), CORSHTTPRequestHandler) as httpd:
             print(f"🚀 服務器啟動在 http://localhost:{PORT}")
             print(f"📁 服務目錄: {os.getcwd()}")
-            print(f"🗺️  地圖測試: http://localhost:{PORT}/map-test.html")
+            print(f"🗺️  地圖測試: http://localhost:{PORT}/simple-map-test.html")
             print(f"📋 行程表: http://localhost:{PORT}/index.html")
             print(f"📦 補給點: http://localhost:{PORT}/supplies.html")
             print("\n按 Ctrl+C 停止服務器")


### PR DESCRIPTION
Update map test HTML filename and references to resolve a file path mismatch.

The `start-server.py` script and `MAP_TROUBLESHOOTING.md` incorrectly referenced `map-test.html`, while the actual file was named `simple-map-test.html`. This PR renames the file and updates all references to ensure consistency and correct server functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9cc4a9e-6734-4dfd-8903-7976ac80a5a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9cc4a9e-6734-4dfd-8903-7976ac80a5a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

